### PR TITLE
Spark variant for missing opptelling

### DIFF
--- a/development/test_note-QualityMissing.ipynb
+++ b/development/test_note-QualityMissing.ipynb
@@ -1,0 +1,204 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SQLContext\n",
+    "from pyspark import SparkContext\n",
+    "from pyspark.sql.types import *\n",
+    "from pyspark.sql import DataFrame\n",
+    "spark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run ../ssb_sparktools/quality/quality.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run ../ssb_sparktools/processing/processing.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "READ_PATH = '/produkt/skatt/person/temp/etablere_klargjoring/skatteobjekt/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "konto = spark.read.path(READ_PATH+'konto')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test = spark_qual_missing(konto)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test.toPandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "minste = spark.read.path(READ_PATH+'minstefradragOgKostnader')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "testminste = spark_qual_missing(minste)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "testminste.toPandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "minste.toPandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tverrsnitt_skattemelding = spark.read.path('/produkt/skatt/person/temp/tverrsnitt_skattemelding')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "so_dict = unpack_parquet(tverrsnitt_skattemelding, \n",
+    "                      rootdf=True, \n",
+    "                      rootvar=['personidentifikator']\n",
+    "                     )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "sc = SparkContext.getOrCreate()\n",
+    "sqlContext = SQLContext(sc)\n",
+    "\n",
+    "missing_variabler = [StructField('dataframe', StringType(), False),\\\n",
+    "                   StructField('variable', StringType(), True),\\\n",
+    "                   StructField('no_missing', IntegerType(), False)]\n",
+    "missing_schema = StructType(missing_variabler)\n",
+    "df_missing = sqlContext.createDataFrame(sc.emptyRDD(), missing_schema)\n",
+    "\n",
+    "for k in so_dict.keys():\n",
+    "    missing_so = spark_qual_missing(so_dict[k], k)\n",
+    "    df_missing = df_missing.union(missing_so)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_missing.toPandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark.read.path('/produkt/skatt/person/temp/missingcorrection_log')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "corrected.filter(corrected['dataframe']=='virtuellValuta').toPandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Pyspark (k8s)",
+   "language": "python",
+   "name": "pyspark_k8s"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Laget ren spark variant som teller opp antall missing for hver variabel på et datasett og returnerer et datasett med den informasjonen. Pandas varianten hadde problem med minne på store dataframes og derfor er det behov for en ren spark variant.

Funksjonen er kalt spark_qual_missing og ligger i quality.py

Opprettet test_note for funksjonen kalt test_note-QualityMissing